### PR TITLE
Set forceLegacyOverBrightClamping

### DIFF
--- a/maps/nano.map
+++ b/maps/nano.map
@@ -2,6 +2,7 @@
 "classname" "worldspawn"
 "message" "Nano^1!"
 "gridsize" "1024 1024 1024"
+"forceLegacyOverBrightClamping" "1"
 {
 ( 160 -816 -16 ) ( 176 -944 -16 ) ( 160 -944 -16 ) nano/e8support06b 0 256 90 0.25 0.25 134217728 0 0
 ( 176 -816 -24 ) ( 176 -816 -16 ) ( 160 -816 -16 ) common/caulk 0 0 0 0.5 0.5 134217728 0 0


### PR DESCRIPTION
The map generally looks worse with the newly enabled full overbright implementation. A lot of lights seem too bright. Lighting of models in the alien base is especially bad: the Overmind is bright despite being in a dark corner and an egg looks as if under bright sunlight.
![unvanquished_2024-04-03_165313_000](https://github.com/InterstellarOasis/map-nano_src.dpkdir/assets/7809431/1afc42a9-b88d-4c29-9e23-ed2436795a76)

![unvanquished_2024-04-03_165320_000](https://github.com/InterstellarOasis/map-nano_src.dpkdir/assets/7809431/9de7ccea-a29a-4a8b-99bb-e6bf40a93d2c)
